### PR TITLE
fix: temp. use local JSONSchema definition

### DIFF
--- a/.changeset/blue-zoos-sneeze.md
+++ b/.changeset/blue-zoos-sneeze.md
@@ -1,0 +1,7 @@
+---
+'@open-rpc/playground': patch
+---
+
+A change to temporarily use local JSONSchema definition to resolve the
+issues surrounding CORS and https://meta.json-schema.tools where we host
+a JSONSchema specfication.

--- a/packages/playground/src/OpenRPCEditor.tsx
+++ b/packages/playground/src/OpenRPCEditor.tsx
@@ -6,6 +6,7 @@ import { debounce } from 'lodash';
 import useDarkMode from 'use-dark-mode';
 import { initWorkers } from './monacoWorker';
 import { getDocumentExtendedMetaSchema } from '@open-rpc/schema-utils-js';
+import { convertToLocalJsonSchema } from './schema/tempLocalJsonSchemaUtils';
 
 interface IProps {
   onChange?: (newValue: string) => void;
@@ -50,7 +51,8 @@ const OpenRPCEditor: React.FC<IProps> = ({ onChange, editorDidMount, onMarkerCha
 
     try {
       const extendedMetaSchema = getDocumentExtendedMetaSchema(JSON.parse(value));
-      addDiagnostics(modelUriString, extendedMetaSchema, monaco);
+      const convertedSchema = convertToLocalJsonSchema(extendedMetaSchema);
+      addDiagnostics(modelUriString, convertedSchema, monaco);
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (e) {
       //console.warn('Invalid OpenRPC Document, skipping schema update');

--- a/packages/playground/src/schema/localJsonSchema.json
+++ b/packages/playground/src/schema/localJsonSchema.json
@@ -1,0 +1,283 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "localJSONSchema",
+  "title": "JSONSchema",
+  "default": {},
+  "oneOf": [
+    {
+      "$ref": "#/definitions/JSONSchemaObject"
+    },
+    {
+      "$ref": "#/definitions/JSONSchemaBoolean"
+    }
+  ],
+  "definitions": {
+    "JSONSchemaBoolean": {
+      "title": "JSONSchemaBoolean",
+      "description": "Always valid if true. Never valid if false. Is constant.",
+      "type": "boolean"
+    },
+    "JSONSchemaObject": {
+      "title": "JSONSchemaObject",
+      "type": "object",
+      "properties": {
+        "$id": {
+          "title": "$id",
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "$schema": {
+          "title": "$schema",
+          "type": "string",
+          "format": "uri"
+        },
+        "$ref": {
+          "title": "$ref",
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "$comment": {
+          "title": "$comment",
+          "type": "string"
+        },
+        "title": {
+          "title": "title",
+          "type": "string"
+        },
+        "description": {
+          "title": "description",
+          "type": "string"
+        },
+        "default": true,
+        "readOnly": {
+          "title": "readOnly",
+          "type": "boolean",
+          "default": false
+        },
+        "examples": {
+          "title": "examples",
+          "type": "array",
+          "items": true
+        },
+        "multipleOf": {
+          "title": "multipleOf",
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "maximum": {
+          "title": "maximum",
+          "type": "number"
+        },
+        "exclusiveMaximum": {
+          "title": "exclusiveMaximum",
+          "type": "number"
+        },
+        "minimum": {
+          "title": "minimum",
+          "type": "number"
+        },
+        "exclusiveMinimum": {
+          "title": "exclusiveMinimum",
+          "type": "number"
+        },
+        "maxLength": {
+          "$ref": "#/definitions/nonNegativeInteger"
+        },
+        "minLength": {
+          "$ref": "#/definitions/nonNegativeIntegerDefault0"
+        },
+        "pattern": {
+          "title": "pattern",
+          "type": "string",
+          "format": "regex"
+        },
+        "additionalItems": {
+          "$ref": "#"
+        },
+        "items": {
+          "title": "items",
+          "anyOf": [
+            {
+              "$ref": "#"
+            },
+            {
+              "$ref": "#/definitions/schemaArray"
+            }
+          ],
+          "default": true
+        },
+        "maxItems": {
+          "$ref": "#/definitions/nonNegativeInteger"
+        },
+        "minItems": {
+          "$ref": "#/definitions/nonNegativeIntegerDefault0"
+        },
+        "uniqueItems": {
+          "title": "uniqueItems",
+          "type": "boolean",
+          "default": false
+        },
+        "contains": {
+          "$ref": "#"
+        },
+        "maxProperties": {
+          "$ref": "#/definitions/nonNegativeInteger"
+        },
+        "minProperties": {
+          "$ref": "#/definitions/nonNegativeIntegerDefault0"
+        },
+        "required": {
+          "$ref": "#/definitions/stringArray"
+        },
+        "additionalProperties": {
+          "$ref": "#"
+        },
+        "definitions": {
+          "title": "definitions",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#"
+          },
+          "default": {}
+        },
+        "properties": {
+          "title": "properties",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#"
+          },
+          "default": {}
+        },
+        "patternProperties": {
+          "title": "patternProperties",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#"
+          },
+          "propertyNames": {
+            "title": "propertyNames",
+            "format": "regex"
+          },
+          "default": {}
+        },
+        "dependencies": {
+          "title": "dependencies",
+          "type": "object",
+          "additionalProperties": {
+            "title": "dependenciesSet",
+            "anyOf": [
+              {
+                "$ref": "#"
+              },
+              {
+                "$ref": "#/definitions/stringArray"
+              }
+            ]
+          }
+        },
+        "propertyNames": {
+          "$ref": "#"
+        },
+        "const": true,
+        "enum": {
+          "title": "enum",
+          "type": "array",
+          "items": true,
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "type": {
+          "title": "type",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/simpleTypes"
+            },
+            {
+              "title": "arrayOfSimpleTypes",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/simpleTypes"
+              },
+              "minItems": 1,
+              "uniqueItems": true
+            }
+          ]
+        },
+        "format": {
+          "title": "format",
+          "type": "string"
+        },
+        "contentMediaType": {
+          "title": "contentMediaType",
+          "type": "string"
+        },
+        "contentEncoding": {
+          "title": "contentEncoding",
+          "type": "string"
+        },
+        "if": {
+          "$ref": "#"
+        },
+        "then": {
+          "$ref": "#"
+        },
+        "else": {
+          "$ref": "#"
+        },
+        "allOf": {
+          "$ref": "#/definitions/schemaArray"
+        },
+        "anyOf": {
+          "$ref": "#/definitions/schemaArray"
+        },
+        "oneOf": {
+          "$ref": "#/definitions/schemaArray"
+        },
+        "not": {
+          "$ref": "#"
+        }
+      }
+    },
+    "schemaArray": {
+      "title": "schemaArray",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#"
+      }
+    },
+    "nonNegativeInteger": {
+      "title": "nonNegativeInteger",
+      "type": "integer",
+      "minimum": 0
+    },
+    "nonNegativeIntegerDefault0": {
+      "title": "nonNegativeIntegerDefaultZero",
+      "type": "integer",
+      "minimum": 0,
+      "default": 0
+    },
+    "simpleTypes": {
+      "title": "simpleTypes",
+      "type": "string",
+      "enum": [
+        "array",
+        "boolean",
+        "integer",
+        "null",
+        "number",
+        "object",
+        "string"
+      ]
+    },
+    "stringArray": {
+      "title": "stringArray",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true,
+      "default": []
+    }
+  }
+}

--- a/packages/playground/src/schema/tempLocalJsonSchemaUtils.ts
+++ b/packages/playground/src/schema/tempLocalJsonSchemaUtils.ts
@@ -1,0 +1,13 @@
+import localJsonSchema from './localJsonSchema.json';
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function convertToLocalJsonSchema(schema: any): any {
+  if (!schema) return schema;
+
+  if (schema.definitions) {
+    schema['definitions'] = { ...schema['definitions'], ...localJsonSchema['definitions'] };
+    schema['definitions']['JSONSchema'] = { oneOf: localJsonSchema.oneOf };
+    schema['definitions']['$ref'] = '#/definitions/JSONSchemaObject.properties.$ref';
+  }
+
+  return schema;
+}


### PR DESCRIPTION
There is a CORS issue fetching from our remote host, using monaco editor for our JSONSchema definition. This change moves the schema definition for the monaco editor purposes to work locally, vs being fetched remotely. When we resolve the upstream issue we may revert or disable the local replacement.