### PR TITLE
fix: this change temporarily points schema resolution to a local copy

### DIFF
--- a/.changeset/legal-hotels-occur.md
+++ b/.changeset/legal-hotels-occur.md
@@ -1,0 +1,5 @@
+---
+'@open-rpc/playground': patch
+---
+
+Temporary fix that works this time moves to local references for meta-schema until CORS issue maybe fixed

--- a/packages/playground/src/OpenRPCEditor.tsx
+++ b/packages/playground/src/OpenRPCEditor.tsx
@@ -55,13 +55,13 @@ const OpenRPCEditor: React.FC<IProps> = ({ onChange, editorDidMount, onMarkerCha
       addDiagnostics(modelUriString, convertedSchema, monaco);
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (e) {
-      //console.warn('Invalid OpenRPC Document, skipping schema update');
+      //console.warn('Invalid OpenRPC Document, skipping schema update', value);
     }
     initWorkers();
 
     // Set up marker change subscription if needed
     if (onMarkerChange) {
-      editor.onDidChangeModelDecorations(
+      editorRef.current?.onDidChangeModelDecorations(
         debounce(() => {
           const markers = monaco.editor.getModelMarkers({
             resource: modelUri,

--- a/packages/playground/src/schema/tempLocalJsonSchemaUtils.ts
+++ b/packages/playground/src/schema/tempLocalJsonSchemaUtils.ts
@@ -2,12 +2,69 @@ import localJsonSchema from './localJsonSchema.json';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function convertToLocalJsonSchema(schema: any): any {
   if (!schema) return schema;
+  const schemaCopy = JSON.parse(JSON.stringify(schema));
 
-  if (schema.definitions) {
-    schema['definitions'] = { ...schema['definitions'], ...localJsonSchema['definitions'] };
-    schema['definitions']['JSONSchema'] = { oneOf: localJsonSchema.oneOf };
-    schema['definitions']['$ref'] = '#/definitions/JSONSchemaObject.properties.$ref';
+  if (!schemaCopy.definitions) {
+    schemaCopy.definitions = {};
   }
 
-  return schema;
+  // Clone localJsonSchema definitions but resolve self-references
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const resolvedDefinitions: Record<string, any> = {};
+
+  Object.entries(schemaCopy.definitions).forEach(([key, def]) => {
+    resolvedDefinitions[key] = JSON.parse(JSON.stringify(def));
+  });
+
+  // Process each definition from localJsonSchema
+  Object.entries(localJsonSchema.definitions).forEach(([key, def]) => {
+    // Deep clone the definition
+    resolvedDefinitions[key] = JSON.parse(JSON.stringify(def));
+  });
+
+  // Function to recursively replace "#" refs with inline schema
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function resolveRefs(obj: any): any {
+    if (!obj || typeof obj !== 'object') return obj;
+
+    if (Array.isArray(obj)) {
+      return obj.map((item) => resolveRefs(item));
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result: Record<string, any> = {};
+    for (const [key, value] of Object.entries(obj)) {
+      if (key === '$ref' && (value === '#' || value === 'https://meta.json-schema.tools')) {
+        // Replace root reference with explicit oneOf
+        return {
+          oneOf: [
+            { $ref: '#/definitions/JSONSchemaObject' },
+            { $ref: '#/definitions/JSONSchemaBoolean' },
+          ],
+        };
+      } else if (typeof value === 'object') {
+        result[key] = resolveRefs(value);
+      } else {
+        result[key] = value;
+      }
+    }
+    return result;
+  }
+
+  // Resolve refs in all definitions
+  for (const key in resolvedDefinitions) {
+    resolvedDefinitions[key] = resolveRefs(resolvedDefinitions[key]);
+  }
+
+  // Merge the resolved definitions
+  schemaCopy.definitions = {
+    ...schemaCopy.definitions,
+    ...resolvedDefinitions,
+  };
+  // Reference object special case
+  schemaCopy['definitions']['referenceObject']['properties']['$ref'] = {
+    $ref: '#/definitions/JSONSchemaObject/properties/$ref',
+  };
+
+  return schemaCopy;
 }


### PR DESCRIPTION
This change is temporary. Earlier patches did not fully resolve the meta-schema locally and caused recursive schema definition errors.