### PR TITLE
Fix schema type display

### DIFF
--- a/.changeset/smooth-mules-join.md
+++ b/.changeset/smooth-mules-join.md
@@ -1,0 +1,6 @@
+---
+'@open-rpc/docs-react': patch
+'@open-rpc/json-schema-to-react-tree': patch
+---
+
+fix array type display when schema type is an array

--- a/package-lock.json
+++ b/package-lock.json
@@ -18918,7 +18918,6 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -18933,19 +18932,16 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -18959,7 +18955,6 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -18975,7 +18970,6 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -28510,12 +28504,12 @@
     },
     "packages/docs-react": {
       "name": "@open-rpc/docs-react",
-      "version": "1.5.1",
+      "version": "2.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@microlink/react-json-view": "1.26.1",
         "@open-rpc/examples": "^1.6.1",
-        "@open-rpc/json-schema-to-react-tree": "0.0.0",
+        "@open-rpc/json-schema-to-react-tree": "0.1.1",
         "@uiw/react-json-view": "^2.0.0-alpha.30",
         "hash-color-material": "^1.1.3",
         "html-url-attributes": "^3.0.1",
@@ -28667,7 +28661,7 @@
     },
     "packages/extensions": {
       "name": "@open-rpc/extensions",
-      "version": "0.0.0",
+      "version": "0.0.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "eslint": "9.21.0",
@@ -28676,11 +28670,11 @@
     },
     "packages/inspector": {
       "name": "@open-rpc/inspector",
-      "version": "1.7.2",
+      "version": "2.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@open-rpc/client-js": "^1.6.3",
-        "@open-rpc/logs-react": "1.2.1",
+        "@open-rpc/logs-react": "2.0.1",
         "@open-rpc/meta-schema": "^1.14.9",
         "@open-rpc/schema-utils-js": "2.1.2",
         "@rehooks/window-size": "^1.0.2",
@@ -28702,7 +28696,7 @@
         "@babel/preset-typescript": "^7.23.3",
         "@mui/icons-material": "6.3.1",
         "@mui/material": "6.3.1",
-        "@open-rpc/monaco-editor-react": "0.0.0",
+        "@open-rpc/monaco-editor-react": "0.1.1",
         "@types/isomorphic-fetch": "^0.0.39",
         "@types/qs": "^6.5.3",
         "@types/react": "18.3.18",
@@ -28726,7 +28720,7 @@
       "peerDependencies": {
         "@mui/icons-material": "6.3.1",
         "@mui/material": "6.3.1",
-        "@open-rpc/monaco-editor-react": "0.0.0",
+        "@open-rpc/monaco-editor-react": "0.1.1",
         "monaco-editor": ">=0.52.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
@@ -28763,7 +28757,7 @@
     },
     "packages/json-schema-to-react-tree": {
       "name": "@open-rpc/json-schema-to-react-tree",
-      "version": "0.0.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",
@@ -28795,7 +28789,7 @@
     },
     "packages/logs-react": {
       "name": "@open-rpc/logs-react",
-      "version": "1.2.1",
+      "version": "2.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@open-rpc/meta-schema": "^1.14.9",
@@ -28813,7 +28807,7 @@
         "@mui/icons-material": "6.3.1",
         "@mui/lab": "6.0.0-beta.22",
         "@mui/material": "6.3.1",
-        "@open-rpc/monaco-editor-react": "0.0.0",
+        "@open-rpc/monaco-editor-react": "0.1.1",
         "@types/react": "18.3.18",
         "@types/react-dom": "18.3.1",
         "babel-loader": "^9.1.3",
@@ -28835,7 +28829,7 @@
         "@mui/icons-material": "6.3.1",
         "@mui/lab": "6.0.0-beta.22",
         "@mui/material": "6.3.1",
-        "@open-rpc/monaco-editor-react": "0.0.0",
+        "@open-rpc/monaco-editor-react": "0.1.1",
         "monaco-editor": ">=0.52.0",
         "react": ">=18.3.1",
         "react-dom": ">=18.3.1"
@@ -28851,7 +28845,7 @@
     },
     "packages/monaco-editor-react": {
       "name": "@open-rpc/monaco-editor-react",
-      "version": "0.0.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.24.0",
@@ -28907,18 +28901,18 @@
     },
     "packages/playground": {
       "name": "@open-rpc/playground",
-      "version": "0.7.1",
+      "version": "1.1.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^11.7.3",
         "@mui/icons-material": "6.3.1",
         "@mui/lab": "6.0.0-beta.22",
         "@mui/material": "6.3.1",
-        "@open-rpc/docs-react": "1.5.1",
+        "@open-rpc/docs-react": "2.1.1",
         "@open-rpc/examples": "^1.3.3",
-        "@open-rpc/inspector": "1.7.2",
+        "@open-rpc/inspector": "2.0.3",
         "@open-rpc/meta-schema": "^1.14.9",
-        "@open-rpc/monaco-editor-react": "0.0.0",
+        "@open-rpc/monaco-editor-react": "0.1.1",
         "@open-rpc/schema-utils-js": "2.1.2",
         "@uiw/react-json-view": "^2.0.0-alpha.30",
         "@use-it/interval": "^0.1.3",

--- a/packages/docs-react/src/JSONSchema/SchemaRenderer.tsx
+++ b/packages/docs-react/src/JSONSchema/SchemaRenderer.tsx
@@ -210,11 +210,10 @@ const SchemaRenderer: React.FC<IProps> = ({ schema, required, name }) => {
       <TableCell
         style={{
           ...styles.cellWidth,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          color: colorMap[schema.type as any],
+          color: Array.isArray(schema.type) ? colorMap.any : colorMap[schema.type as any],
         }}
       >
-        {schema.type}
+        {Array.isArray(schema.type) ? (schema.type as string[]).join(' | ') : schema.type}
       </TableCell>
       <TableCell style={styles.cellWidth}>{schema.pattern}</TableCell>
       <TableCell style={styles.cellWidth}>{required ? 'true' : 'false'}</TableCell>

--- a/packages/json-schema-to-react-tree/src/containers/JSONSchemaTree.tsx
+++ b/packages/json-schema-to-react-tree/src/containers/JSONSchemaTree.tsx
@@ -300,8 +300,9 @@ const RenderNodes: React.FC<IRenderNodes> = ({ schema, required }) => {
               >
                 type
               </Typography>
-              {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-              <Typography style={{ color: colorMap[schema.type as any] }}>{schema.type}</Typography>
+              <Typography style={{ color: Array.isArray(schema.type) ? colorMap.any : colorMap[schema.type as any] }}>
+                {Array.isArray(schema.type) ? schema.type.join(' | ') : schema.type}
+              </Typography>
             </Grid>
           }
           itemId={uuid()}


### PR DESCRIPTION
## Summary
- fix array type display in docs-react SchemaRenderer
- fix array type display in json-schema-to-react-tree
- add a changeset for docs-react and json-schema-to-react-tree

## Testing
- `npm run lint` *(fails: missing dependencies)*
- `npm run test` *(fails: cannot build packages)*
