### PR TITLE
Fix tests and add AGENT instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENT Instructions
+
+Before committing any changes, contributors MUST run `npm test` and `npm run lint` from the repository root and ensure both pass.

--- a/packages/docs-react/vitest.config.ts
+++ b/packages/docs-react/vitest.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
+
+const alias = {
+  '@open-rpc/json-schema-to-react-tree': resolve(__dirname, '../json-schema-to-react-tree/src'),
+};
 
 export default defineConfig({
+  resolve: { alias },
   test: {
     environment: 'jsdom',
     globals: true,

--- a/packages/logs-react/vite.config.ts
+++ b/packages/logs-react/vite.config.ts
@@ -37,6 +37,7 @@ export default defineConfig({
         '@mui/icons-material',
         '@mui/lab',
         'monaco-editor',
+        '@open-rpc/monaco-editor-react',
       ],
     },
   },

--- a/turbo.json
+++ b/turbo.json
@@ -20,7 +20,6 @@
       "cache": false
     },
     "test": {
-      "dependsOn": ["^build:package"],
       "outputs": ["coverage/**"],
       "inputs": ["src/**", "test/**"],
       "cache": false


### PR DESCRIPTION
## Summary
- remove build step requirement from tests
- add alias for json-schema tree in docs-react tests
- keep monaco editor react external during logs-react build
- document testing requirements in AGENTS.md

## Testing
- `npm test`
- `npm run lint`
