### PR TITLE
Fix union type display

### DIFF
--- a/.changeset/wicked-meals-lie.md
+++ b/.changeset/wicked-meals-lie.md
@@ -1,0 +1,5 @@
+---
+"@open-rpc/docs-react": patch
+"@open-rpc/json-schema-to-react-tree": patch
+---
+Fix display of union schema types by joining array types with " | " instead of concatenating.

--- a/packages/docs-react/src/JSONSchema/SchemaRenderer.tsx
+++ b/packages/docs-react/src/JSONSchema/SchemaRenderer.tsx
@@ -189,6 +189,13 @@ const SchemaRenderer: React.FC<IProps> = ({ schema, required, name }) => {
     );
   }
 
+  const formatType = (type?: JSONSchema4['type']) => {
+    if (Array.isArray(type)) {
+      return type.join(' | ');
+    }
+    return type;
+  };
+
   const colorMap: { [k: string]: string } = {
     any: grey[500],
     array: blue[300],
@@ -198,6 +205,7 @@ const SchemaRenderer: React.FC<IProps> = ({ schema, required, name }) => {
     number: purple[500],
     string: green[500],
     undefined: grey[500],
+    union: grey[500],
   };
   return (
     <TableRow key={schema.title}>
@@ -211,10 +219,10 @@ const SchemaRenderer: React.FC<IProps> = ({ schema, required, name }) => {
         style={{
           ...styles.cellWidth,
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          color: colorMap[schema.type as any],
+          color: Array.isArray(schema.type) ? colorMap.union : colorMap[schema.type as any],
         }}
       >
-        {schema.type}
+        {formatType(schema.type)}
       </TableCell>
       <TableCell style={styles.cellWidth}>{schema.pattern}</TableCell>
       <TableCell style={styles.cellWidth}>{required ? 'true' : 'false'}</TableCell>

--- a/packages/json-schema-to-react-tree/src/containers/JSONSchemaTree.tsx
+++ b/packages/json-schema-to-react-tree/src/containers/JSONSchemaTree.tsx
@@ -9,6 +9,13 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import { v4 as uuid } from 'uuid';
 
+const formatType = (type?: JSONSchema7['type']) => {
+  if (Array.isArray(type)) {
+    return type.join(' | ');
+  }
+  return type;
+};
+
 const colorMap: { [k: string]: string } = {
   any: grey[500],
   array: blue[400],
@@ -25,6 +32,7 @@ const colorMap: { [k: string]: string } = {
   anyof: blue[200],
   allof: blue.A700,
   enum: green[900],
+  union: grey[500],
 };
 
 interface IProps {
@@ -301,7 +309,13 @@ const RenderNodes: React.FC<IRenderNodes> = ({ schema, required }) => {
                 type
               </Typography>
               {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-              <Typography style={{ color: colorMap[schema.type as any] }}>{schema.type}</Typography>
+              <Typography
+                style={{
+                  color: Array.isArray(schema.type) ? colorMap.union : colorMap[schema.type as any],
+                }}
+              >
+                {formatType(schema.type)}
+              </Typography>
             </Grid>
           }
           itemId={uuid()}


### PR DESCRIPTION
## Summary
- properly display union types in JSONSchema tables
- show union type color as `union`

## Testing
- `npm test`
- `npm run lint`
